### PR TITLE
Pipeline Polishing

### DIFF
--- a/.github/workflows/update-draft-release.yml
+++ b/.github/workflows/update-draft-release.yml
@@ -42,14 +42,16 @@ jobs:
 
                 PAYLOAD=$(yj -tj < buildpack.toml | jq '{ primary: . }')
 
-                for PACKAGE in $(yj -t < package.toml | jq -r '.dependencies[].image'); do
-                  PAYLOAD=$(jq -n -r \
-                    --argjson PAYLOAD "${PAYLOAD}" \
-                    --argjson BUILDPACK "$(crane export "${PACKAGE}" - \
-                      | tar xOf - --absolute-names --wildcards "/cnb/buildpacks/*/*/buildpack.toml" \
-                      | yj -tj)" \
-                    '$PAYLOAD | .buildpacks += [ $BUILDPACK ]')
-                done
+                if [[ -e package.toml ]]; then
+                  for PACKAGE in $(yj -t < package.toml | jq -r '.dependencies[].image'); do
+                    PAYLOAD=$(jq -n -r \
+                      --argjson PAYLOAD "${PAYLOAD}" \
+                      --argjson BUILDPACK "$(crane export "${PACKAGE}" - \
+                        | tar xOf - --absolute-names --wildcards "/cnb/buildpacks/*/*/buildpack.toml" \
+                        | yj -tj)" \
+                      '$PAYLOAD | .buildpacks += [ $BUILDPACK ]')
+                  done
+                fi
 
                 jq -n -r \
                   --argjson PAYLOAD "${PAYLOAD}" \


### PR DESCRIPTION
This change polishes up the draft release notes pipeline to handle buildpacks without package.toml better.
