### PR TITLE
GitHub Token

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -1,3 +1,5 @@
+github_token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+
 codeowners:
 - path:  "*"
   owner: "@paketo-buildpacks/java-buildpacks"
@@ -60,4 +62,4 @@ dependencies:
   with:
     owner:      cloudfoundry
     repository: jvmkill
-    token:      ${{ secrets.GITHUB_TOKEN }}
+    token:      ${{ secrets.JAVA_GITHUB_TOKEN }}

--- a/.github/workflows/update-pipeline.yml
+++ b/.github/workflows/update-pipeline.yml
@@ -56,7 +56,7 @@ jobs:
                 echo "::set-output name=release-notes::${RELEASE_NOTES//$'\n'/%0A}"
               env:
                 DESCRIPTOR: .github/pipeline-descriptor.yml
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.JAVA_GITHUB_TOKEN }}
             - uses: peter-evans/create-pull-request@v3
               with:
                 body: |-
@@ -75,4 +75,4 @@ jobs:
                 labels: semver:patch, type:task
                 signoff: true
                 title: Bump pipeline from ${{ steps.pipeline.outputs.old-version }} to ${{ steps.pipeline.outputs.new-version }}
-                token: ${{ secrets.GITHUB_TOKEN }}
+                token: ${{ secrets.JAVA_GITHUB_TOKEN }}


### PR DESCRIPTION
Previously all of the workflows used secrets.GITHUB_TOKEN.  In the end the de-privileged nature of this token proved to be too much and this change migrates the workflows to use bot-specific token instead.