### PR TITLE
Configure Java 8 to update CPE info

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -20,6 +20,7 @@ dependencies:
 - name:            JDK 8
   id:              jdk
   version_pattern: "8\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "update[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
   with:
     type:    jdk
@@ -27,6 +28,7 @@ dependencies:
 - name:            JRE 8
   id:              jre
   version_pattern: "8\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "update[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
   with:
     type:    headfull

--- a/.github/workflows/update-jdk-8.yml
+++ b/.github/workflows/update-jdk-8.yml
@@ -87,7 +87,7 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: update[\d]+
                 ID: jdk
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: ""

--- a/.github/workflows/update-jre-8.yml
+++ b/.github/workflows/update-jre-8.yml
@@ -87,7 +87,7 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: update[\d]+
                 ID: jre
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: ""


### PR DESCRIPTION
## Summary
Java 8 has a slightly different CPE format. This change will allow the update script to update the CPE info for Java 8.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
