### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/azul-zulu`
 
-The Paketo Azul Zulu Buildpack is a Cloud Native Buildpack that provides the Azul Zulu implementations of JREs and JDKs.
+The Paketo Buildpack for Azul Zulu is a Cloud Native Buildpack that provides the Azul Zulu implementations of JREs and JDKs.
 
 This buildpack is designed to work in collaboration with other buildpacks which request contributions of JREs and JDKs.
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/azul-zulu"
   id = "paketo-buildpacks/azul-zulu"
   keywords = ["java", "jvm", "jre", "jdk"]
-  name = "Paketo Azul Zulu Buildpack"
+  name = "Paketo Buildpack for Azul Zulu"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Azul Zulu Buildpack' to 'Paketo Buildpack for Azul Zulu'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
