### PR TITLE
Change the type filter for JVM updates

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -34,7 +34,7 @@ dependencies:
   cpe_pattern:     "update[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
   with:
-    type:    headfull
+    type:    jre
     version: "8"
 - name:            JDK 11
   id:              jdk
@@ -48,7 +48,7 @@ dependencies:
   version_pattern: "11\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
   with:
-    type:    headfull
+    type:    jre
     version: "11"
 - name:            JDK 17
   id:              jdk
@@ -62,7 +62,7 @@ dependencies:
   version_pattern: "17\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
   with:
-    type:    headfull
+    type:    jre
     version: "17"
 - name:            JDK 20
   id:              jdk
@@ -76,5 +76,5 @@ dependencies:
   version_pattern: "20\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
   with:
-    type:    headfull
+    type:    jre
     version: "20"

--- a/.github/workflows/pb-update-jre-11.yml
+++ b/.github/workflows/pb-update-jre-11.yml
@@ -44,7 +44,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
               with:
-                type: headfull
+                type: jre
                 version: "11"
             - name: Update Buildpack Dependency
               id: buildpack

--- a/.github/workflows/pb-update-jre-17.yml
+++ b/.github/workflows/pb-update-jre-17.yml
@@ -44,7 +44,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
               with:
-                type: headfull
+                type: jre
                 version: "17"
             - name: Update Buildpack Dependency
               id: buildpack

--- a/.github/workflows/pb-update-jre-20.yml
+++ b/.github/workflows/pb-update-jre-20.yml
@@ -44,7 +44,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
               with:
-                type: headfull
+                type: jre
                 version: "20"
             - name: Update Buildpack Dependency
               id: buildpack

--- a/.github/workflows/pb-update-jre-8.yml
+++ b/.github/workflows/pb-update-jre-8.yml
@@ -44,7 +44,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
               with:
-                type: headfull
+                type: jre
                 version: "8"
             - name: Update Buildpack Dependency
               id: buildpack


### PR DESCRIPTION

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The update to use the Azul Metadata API in the updater requires different filters. It now uses just `jdk` or `jre`.

## Use Cases
Fix broken updates

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
