### PR TITLE
Add jdk 23 for amd64 architecture

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -265,6 +265,20 @@ api = "0.7"
       uri = "https://openjdk.java.net/legal/gplv2+ce.html"
 
   [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:oracle:jdk:23.0.1:*:*:*:*:*:*:*", "cpe:2.3:a:azul:zulu:23.0.1:*:*:*:*:*:*:*"]
+    id = "jdk"
+    name = "Azul Zulu JDK"
+    purl = "pkg:generic/azul-zulu-jdk@23.0.1?arch=amd64"
+    sha256 = "ac016766bf3e6b6f6fad79925f0510eeb817e86f0380fbc08a81d2754eb89092"
+    stacks = ["*"]
+    uri = "https://cdn.azul.com/zulu/bin/zulu23.30.13-ca-jdk23.0.1-linux_x64.tar.gz"
+    version = "23.0.1"
+
+    [[metadata.dependencies.licenses]]
+      type = "GPL-2.0 WITH Classpath-exception-2.0"
+      uri = "https://openjdk.java.net/legal/gplv2+ce.html"
+
+  [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:oracle:jre:23.0.1:*:*:*:*:*:*:*", "cpe:2.3:a:azul:zulu:23.0.1:*:*:*:*:*:*:*"]
     id = "jre"
     name = "Azul Zulu JRE"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This change adds a dependency for jdk 23 for amd64 architecture.

## Use Cases
It is currently missing and builds that require it will fail.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
